### PR TITLE
Add Home Assistant mental load assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# mental-load-list
+# Mental Load Assistant for Home Assistant
+
+Dieses Projekt stellt eine benutzerdefinierte Home-Assistant-Integration bereit, die Kalender-Einträge und manuelle Aufgaben automatisch in übersichtliche Schritte aufteilt und nach Mental-Load-Kriterien strukturiert. Die erzeugten Aufgaben erscheinen als To-do-/Kanban-Liste innerhalb von Home Assistant.
+
+## Funktionsumfang
+
+- **Kalender-Analyse**: Überwachte Kalender (Google, Microsoft, lokale Kalender usw.) werden regelmäßig abgefragt. Jeder Termin wird per KI analysiert und in konkrete To-dos zerlegt.
+- **Manuelle Aufgaben**: Eigene Einträge lassen sich direkt in der To-do-Liste oder per Service hinzufügen. Auch diese Aufgaben werden automatisch in Unteraufgaben aufgeteilt.
+- **Mental-Load-Bewertung**: Für jede Aufgabe werden Hinweise zur mentalen Belastung sowie optionale Notizen bereitgestellt.
+- **Fallback ohne API-Schlüssel**: Falls kein KI-Dienst konfiguriert ist oder der Aufruf fehlschlägt, greift eine nachvollziehbare Heuristik zur Generierung der Teilaufgaben.
+- **Service-Aufrufe**: Über `mental_load_assistant.add_manual_task` können Aufgaben samt Kontext (Beschreibung, Fälligkeitsdatum, Haushaltsinformationen) per Automatisierung hinzugefügt werden.
+
+## Installation
+
+1. Kopiere den Ordner `custom_components/mental_load_assistant` in dein Home-Assistant-Konfigurationsverzeichnis.
+2. Starte Home Assistant neu.
+3. Öffne *Einstellungen → Geräte & Dienste → Integration hinzufügen* und suche nach **Mental Load Assistant**.
+4. Wähle die Kalender aus, die analysiert werden sollen. Optional kann ein OpenAI-kompatibler API-Schlüssel und ein Modellname hinterlegt werden.
+
+## Optionen
+
+- **Modell**: Name des Chat-Modells (Standard: `gpt-4o-mini`).
+- **Abfrageintervall**: Wie oft Kalender synchronisiert werden.
+- **Zeithorizont**: Zeitraum in die Zukunft, der aus dem Kalender analysiert wird.
+
+## Services
+
+```yaml
+domain: mental_load_assistant
+service: add_manual_task
+data:
+  summary: "Solaranlage reparieren"
+  description: "Wechselrichter zeigt Fehlercode an"
+  due: "2024-07-01T18:00:00+02:00"
+  household_context: "Eigenheim mit PV-Anlage"
+```
+
+## Hinweise zur KI-Nutzung
+
+- Die Integration verwendet die OpenAI-kompatible Chat-Completions-API. Der API-Schlüssel wird serverseitig gespeichert und ausschließlich für die Aufgabengenerierung genutzt.
+- Ohne gültigen Schlüssel oder bei Kommunikationsproblemen werden sinnvolle Standard-Aufgaben erzeugt, damit die Liste nutzbar bleibt.
+- Die erzeugten Aufgaben enthalten zusätzliche Metadaten (Quelle, Elternaufgabe, Mental-Load-Notizen) und können wie jede andere To-do-Liste in Home Assistant verwendet werden.
+
+## Weiterentwicklung
+
+- Unterstützung weiterer KI-Anbieter über konfigurierbare Endpunkte
+- Persistente Speicherung bereits analysierter Ereignisse über den Neustart hinaus
+- Erstellen mehrerer Listen mit unterschiedlichen Kalenderquellen

--- a/custom_components/mental_load_assistant/__init__.py
+++ b/custom_components/mental_load_assistant/__init__.py
@@ -1,0 +1,172 @@
+"""Mental Load Assistant integration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, CONF_NAME, Platform
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import aiohttp_client, config_validation as cv
+
+from .ai_client import MentalLoadAI
+from .const import (
+    CONF_CALENDARS,
+    CONF_HOUSEHOLD_CONTEXT,
+    CONF_MODEL,
+    CONF_POLL_INTERVAL,
+    CONF_TIME_HORIZON,
+    DATA_COORDINATOR,
+    DATA_MANAGER,
+    DATA_UNSUB_UPDATE_LISTENER,
+    DEFAULT_MODEL,
+    DEFAULT_POLL_INTERVAL,
+    DEFAULT_TIME_HORIZON,
+    DOMAIN,
+    SERVICE_ADD_TASK,
+)
+from .coordinator import MentalLoadCoordinator
+from .task_manager import MentalLoadTaskManager
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.TODO]
+
+
+def _get_entry_option(entry: ConfigEntry, option: str, default: Any) -> Any:
+    """Return option value from entry with fallback to default."""
+    if option in entry.options:
+        return entry.options[option]
+    return entry.data.get(option, default)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the integration from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
+    session = aiohttp_client.async_get_clientsession(hass)
+
+    model = _get_entry_option(entry, CONF_MODEL, DEFAULT_MODEL)
+    poll_interval = _get_entry_option(entry, CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
+    time_horizon = _get_entry_option(entry, CONF_TIME_HORIZON, DEFAULT_TIME_HORIZON)
+
+    ai_client = MentalLoadAI(
+        session=session,
+        api_key=entry.data.get(CONF_API_KEY),
+        model=model,
+    )
+
+    manager = MentalLoadTaskManager(
+        hass=hass,
+        ai_client=ai_client,
+        title=entry.data.get(CONF_NAME, "Mental Load"),
+    )
+
+    coordinator = MentalLoadCoordinator(
+        hass=hass,
+        calendars=entry.data.get(CONF_CALENDARS, []),
+        manager=manager,
+        poll_interval=poll_interval,
+        time_horizon=time_horizon,
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        DATA_MANAGER: manager,
+        DATA_COORDINATOR: coordinator,
+        DATA_UNSUB_UPDATE_LISTENER: entry.add_update_listener(async_update_entry),
+    }
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    _register_services(hass)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    data = hass.data[DOMAIN].pop(entry.entry_id)
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    unsub: Callable[[], None] | None = data.get(DATA_UNSUB_UPDATE_LISTENER)
+    if unsub is not None:
+        unsub()
+
+    if not hass.data[DOMAIN]:
+        _unregister_services(hass)
+
+    return unload_ok
+
+
+async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    data = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator: MentalLoadCoordinator = data[DATA_COORDINATOR]
+    coordinator.update_parameters(
+        calendars=entry.data.get(CONF_CALENDARS, []),
+        poll_interval=_get_entry_option(entry, CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
+        time_horizon=_get_entry_option(entry, CONF_TIME_HORIZON, DEFAULT_TIME_HORIZON),
+    )
+    await coordinator.async_request_refresh()
+
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register integration level services."""
+
+    if hass.services.has_service(DOMAIN, SERVICE_ADD_TASK):
+        return
+
+    service_schema = vol.Schema(
+        {
+            vol.Optional("entry_id"): cv.string,
+            vol.Required("summary"): cv.string,
+            vol.Optional("description"): cv.string,
+            vol.Optional("due"): vol.Any(cv.datetime, cv.string),
+            vol.Optional(CONF_HOUSEHOLD_CONTEXT): cv.string,
+        }
+    )
+
+    async def _async_handle_add_task(call: ServiceCall) -> None:
+        entry_id = call.data.get("entry_id")
+        manager: MentalLoadTaskManager | None = None
+
+        if entry_id:
+            entry_data = hass.data.get(DOMAIN, {}).get(entry_id)
+            if entry_data:
+                manager = entry_data.get(DATA_MANAGER)
+        else:
+            # Pick the first available manager if only one integration is configured
+            if len(hass.data.get(DOMAIN, {})) == 1:
+                manager = next(iter(hass.data[DOMAIN].values())).get(DATA_MANAGER)
+
+        if not manager:
+            _LOGGER.error("No Mental Load integration instance available for service call")
+            return
+
+        await manager.async_create_manual_entry(
+            summary=call.data["summary"],
+            description=call.data.get("description"),
+            due=call.data.get("due"),
+            household_context=call.data.get(CONF_HOUSEHOLD_CONTEXT),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ADD_TASK,
+        _async_handle_add_task,
+        schema=service_schema,
+    )
+
+
+def _unregister_services(hass: HomeAssistant) -> None:
+    """Remove registered services if no instances remain."""
+    if hass.services.has_service(DOMAIN, SERVICE_ADD_TASK):
+        hass.services.async_remove(DOMAIN, SERVICE_ADD_TASK)

--- a/custom_components/mental_load_assistant/ai_client.py
+++ b/custom_components/mental_load_assistant/ai_client.py
@@ -1,0 +1,269 @@
+"""Client responsible for AI based task planning."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import aiohttp
+
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MentalLoadAIError(Exception):
+    """Raised when the AI backend cannot be reached or parsed."""
+
+
+@dataclass
+class PlannedTask:
+    """Task as returned by the AI model."""
+
+    title: str
+    description: str | None = None
+    due: datetime | None = None
+    effort: str | None = None
+    category: str | None = None
+    notes: str | None = None
+
+
+@dataclass
+class PlannedResponse:
+    """Full response from the AI model."""
+
+    tasks: list[PlannedTask]
+    mental_load: str | None
+    summary_notes: str | None
+
+
+class MentalLoadAI:
+    """Wrapper around a chat completion API with graceful degradation."""
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        api_key: str | None,
+        model: str,
+        base_url: str = "https://api.openai.com/v1",
+    ) -> None:
+        self._session = session
+        self._api_key = api_key
+        self._model = model
+        self._base_url = base_url.rstrip("/")
+
+    async def async_plan_for_calendar_event(
+        self,
+        *,
+        summary: str,
+        description: str | None,
+        start: datetime | None,
+        end: datetime | None,
+        household_context: str | None = None,
+    ) -> PlannedResponse:
+        """Create a task plan for a calendar event."""
+
+        payload: dict[str, Any] = {
+            "type": "calendar_event",
+            "summary": summary,
+            "description": description,
+            "start": dt_util.as_utc(start).isoformat() if start else None,
+            "end": dt_util.as_utc(end).isoformat() if end else None,
+            "household_context": household_context,
+        }
+        return await self._async_generate_plan(payload)
+
+    async def async_plan_for_manual_request(
+        self,
+        *,
+        summary: str,
+        description: str | None,
+        due: datetime | None,
+        household_context: str | None = None,
+    ) -> PlannedResponse:
+        """Create a task plan for a free form manual request."""
+
+        payload: dict[str, Any] = {
+            "type": "manual_task",
+            "summary": summary,
+            "description": description,
+            "due": dt_util.as_utc(due).isoformat() if due else None,
+            "household_context": household_context,
+        }
+        return await self._async_generate_plan(payload)
+
+    async def _async_generate_plan(self, payload: dict[str, Any]) -> PlannedResponse:
+        """Call the AI backend or use a deterministic fallback."""
+
+        if not self._api_key:
+            _LOGGER.debug("No API key configured, using heuristic plan")
+            return self._fallback_plan(payload)
+
+        try:
+            response = await self._session.post(
+                f"{self._base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=aiohttp.ClientTimeout(total=60),
+                json={
+                    "model": self._model,
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "mental_load_task_plan",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "mental_load": {"type": "string"},
+                                    "summary_notes": {"type": "string"},
+                                    "tasks": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {"type": "string"},
+                                                "description": {"type": "string"},
+                                                "due": {"type": "string"},
+                                                "effort": {"type": "string"},
+                                                "category": {"type": "string"},
+                                                "notes": {"type": "string"},
+                                            },
+                                            "required": ["title"],
+                                        },
+                                    },
+                                },
+                                "required": ["tasks"],
+                            },
+                        },
+                    },
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": (
+                                "You break down household calendar events into actionable tasks. "
+                                "Keep tasks short and concrete."
+                            ),
+                        },
+                        {
+                            "role": "user",
+                            "content": json.dumps({"request": payload}),
+                        },
+                    ],
+                    "temperature": 0.2,
+                },
+            )
+            data = await response.json()
+            if response.status >= 400:
+                raise MentalLoadAIError(data)
+            content = data["choices"][0]["message"]["content"]
+            return self._parse_response(content)
+        except (aiohttp.ClientError, KeyError, json.JSONDecodeError, MentalLoadAIError) as err:
+            _LOGGER.warning("Falling back to heuristic plan due to AI error: %s", err)
+            return self._fallback_plan(payload)
+
+    def _parse_response(self, content: str) -> PlannedResponse:
+        """Parse a JSON response from the chat API."""
+
+        parsed = json.loads(content)
+        tasks = [self._task_from_dict(item) for item in parsed.get("tasks", [])]
+        return PlannedResponse(
+            tasks=tasks,
+            mental_load=parsed.get("mental_load"),
+            summary_notes=parsed.get("summary_notes"),
+        )
+
+    def _task_from_dict(self, item: dict[str, Any]) -> PlannedTask:
+        """Convert a dictionary to a PlannedTask instance."""
+
+        due_value = item.get("due")
+        due_dt: datetime | None = None
+        if isinstance(due_value, str):
+            try:
+                due_dt = dt_util.parse_datetime(due_value)
+            except (ValueError, TypeError):
+                due_dt = None
+
+        return PlannedTask(
+            title=item.get("title", "Unnamed task"),
+            description=item.get("description"),
+            due=dt_util.as_utc(due_dt) if due_dt else None,
+            effort=item.get("effort"),
+            category=item.get("category"),
+            notes=item.get("notes"),
+        )
+
+    def _fallback_plan(self, payload: dict[str, Any]) -> PlannedResponse:
+        """Provide a deterministic fallback plan when AI is unavailable."""
+
+        summary = payload.get("summary") or "Aufgabe"
+        description = payload.get("description")
+        base_due = _parse_dt(payload.get("due")) or _parse_dt(payload.get("end"))
+
+        tasks = _default_breakdown(summary, description)
+
+        planned_tasks = [
+            PlannedTask(
+                title=title,
+                description=details,
+                due=base_due,
+            )
+            for title, details in tasks
+        ]
+
+        return PlannedResponse(
+            tasks=planned_tasks,
+            mental_load="unknown",
+            summary_notes="Automatisch erzeugter Plan (Fallback)",
+        )
+
+
+def _default_breakdown(summary: str, description: str | None) -> list[tuple[str, str | None]]:
+    """Simple heuristic breakdown for offline mode."""
+
+    components: list[tuple[str, str | None]] = []
+    normalized = summary.lower()
+
+    if any(keyword in normalized for keyword in ("repar", "fix", "repair")):
+        components.extend(
+            [
+                ("Problem verstehen und Dokumentation prüfen", description),
+                ("Benötigte Teile oder Service organisieren", None),
+                ("Reparatur durchführen und testen", None),
+            ]
+        )
+    elif any(keyword in normalized for keyword in ("geburtstag", "party", "feier")):
+        components.extend(
+            [
+                ("Gästeliste und Einladungen", description),
+                ("Einkaufsliste und Dekoration planen", None),
+                ("Vorbereitung am Veranstaltungstag", None),
+            ]
+        )
+    else:
+        components.extend(
+            [
+                ("Aufgabe planen", description),
+                ("Ressourcen beschaffen", None),
+                ("Durchführung abschließen", None),
+            ]
+        )
+
+    return components
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    """Parse a datetime value."""
+
+    if isinstance(value, datetime):
+        return dt_util.as_utc(value)
+    if isinstance(value, str):
+        try:
+            return dt_util.as_utc(dt_util.parse_datetime(value))
+        except (ValueError, TypeError):
+            return None
+    return None

--- a/custom_components/mental_load_assistant/config_flow.py
+++ b/custom_components/mental_load_assistant/config_flow.py
@@ -1,0 +1,127 @@
+"""Config flow for the Mental Load Assistant."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from datetime import timedelta
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_API_KEY, CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
+
+from .const import (
+    CONF_CALENDARS,
+    CONF_MODEL,
+    CONF_POLL_INTERVAL,
+    CONF_TIME_HORIZON,
+    DEFAULT_MODEL,
+    DEFAULT_POLL_INTERVAL,
+    DEFAULT_TIME_HORIZON,
+    DOMAIN,
+)
+
+
+def _duration_to_selector(value: timedelta | dict[str, int]) -> dict[str, int]:
+    if isinstance(value, dict):
+        return value
+    total_seconds = int(value.total_seconds())
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return {
+        "days": days,
+        "hours": hours,
+        "minutes": minutes,
+        "seconds": seconds,
+    }
+
+
+def _selector_to_timedelta(value: dict[str, int] | timedelta) -> timedelta:
+    if isinstance(value, timedelta):
+        return value
+    return timedelta(
+        days=value.get("days", 0),
+        hours=value.get("hours", 0),
+        minutes=value.get("minutes", 0),
+        seconds=value.get("seconds", 0),
+    )
+
+
+class MentalLoadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for the integration."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is None:
+            calendars = list(self.hass.states.async_entity_ids("calendar"))
+            data_schema = vol.Schema(
+                {
+                    vol.Required(CONF_NAME, default="Mental Load"): str,
+                    vol.Optional(CONF_API_KEY): str,
+                    vol.Optional(CONF_MODEL, default=DEFAULT_MODEL): str,
+                    vol.Required(CONF_CALENDARS): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=calendars,
+                            multiple=True,
+                            custom_value=False,
+                        )
+                    ),
+                }
+            )
+            return self.async_show_form(step_id="user", data_schema=data_schema)
+
+        return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+    async def async_step_import(self, user_input: dict) -> FlowResult:
+        return await self.async_step_user(user_input)
+
+    async def async_step_options(self) -> FlowResult:
+        return await self.async_step_user()
+
+
+class MentalLoadOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options for an existing entry."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self._entry = config_entry
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is None:
+            data_schema = vol.Schema(
+                {
+                    vol.Optional(CONF_MODEL, default=self._entry.options.get(CONF_MODEL, self._entry.data.get(CONF_MODEL, DEFAULT_MODEL))): str,
+                    vol.Optional(
+                        CONF_POLL_INTERVAL,
+                        default=_duration_to_selector(
+                            self._entry.options.get(
+                                CONF_POLL_INTERVAL,
+                                self._entry.data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
+                            )
+                        ),
+                    ): selector.DurationSelector(),
+                    vol.Optional(
+                        CONF_TIME_HORIZON,
+                        default=_duration_to_selector(
+                            self._entry.options.get(
+                                CONF_TIME_HORIZON,
+                                self._entry.data.get(CONF_TIME_HORIZON, DEFAULT_TIME_HORIZON),
+                            )
+                        ),
+                    ): selector.DurationSelector(),
+                }
+            )
+            return self.async_show_form(step_id="init", data_schema=data_schema)
+
+        data = dict(user_input)
+        for key in (CONF_POLL_INTERVAL, CONF_TIME_HORIZON):
+            if key in data and isinstance(data[key], dict):
+                data[key] = _selector_to_timedelta(data[key])
+
+        return self.async_create_entry(title="Options", data=data)
+
+
+async def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> MentalLoadOptionsFlowHandler:
+    return MentalLoadOptionsFlowHandler(config_entry)

--- a/custom_components/mental_load_assistant/const.py
+++ b/custom_components/mental_load_assistant/const.py
@@ -1,0 +1,35 @@
+"""Constants for the Mental Load Assistant integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.const import CONF_API_KEY
+
+DOMAIN = "mental_load_assistant"
+
+CONF_CALENDARS = "calendars"
+CONF_MODEL = "model"
+CONF_POLL_INTERVAL = "poll_interval"
+CONF_TIME_HORIZON = "time_horizon"
+
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_POLL_INTERVAL = timedelta(minutes=15)
+DEFAULT_TIME_HORIZON = timedelta(days=14)
+
+DATA_MANAGER = "manager"
+DATA_COORDINATOR = "coordinator"
+DATA_UNSUB_UPDATE_LISTENER = "update_listener"
+
+SERVICE_ADD_TASK = "add_manual_task"
+
+ATTR_SOURCE = "source"
+ATTR_PARENT_UID = "parent_uid"
+ATTR_MENTAL_LOAD = "mental_load"
+
+MANUAL_SOURCE = "manual"
+CALENDAR_SOURCE = "calendar"
+
+CONF_HOUSEHOLD_CONTEXT = "household_context"
+
+STORAGE_KEY_EVENTS = "events"

--- a/custom_components/mental_load_assistant/coordinator.py
+++ b/custom_components/mental_load_assistant/coordinator.py
@@ -1,0 +1,91 @@
+"""Data update coordinator for calendar sync."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Iterable
+
+from homeassistant.components.calendar import CalendarEvent, async_get_events
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from .task_manager import MentalLoadTaskManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MentalLoadCoordinator(DataUpdateCoordinator[None]):
+    """Coordinate updates between calendars and task manager."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        calendars: Iterable[str],
+        manager: MentalLoadTaskManager,
+        poll_interval: timedelta,
+        time_horizon: timedelta,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Mental Load Coordinator",
+            update_interval=poll_interval,
+        )
+        self._calendars = list(calendars)
+        self._manager = manager
+        self._time_horizon = time_horizon
+
+    def update_parameters(
+        self,
+        *,
+        calendars: Iterable[str] | None = None,
+        poll_interval: timedelta | None = None,
+        time_horizon: timedelta | None = None,
+    ) -> None:
+        """Update runtime parameters."""
+
+        if calendars is not None:
+            self._calendars = list(calendars)
+        if poll_interval is not None:
+            self.update_interval = poll_interval
+        if time_horizon is not None:
+            self._time_horizon = time_horizon
+
+    async def _async_update_data(self) -> None:
+        """Fetch events and update tasks."""
+        if not self._calendars:
+            return
+
+        now = dt_util.utcnow()
+        start = now - timedelta(days=1)
+        end = now + self._time_horizon
+        observed_parents: set[str] = set()
+
+        for calendar_id in self._calendars:
+            try:
+                events = await async_get_events(self.hass, calendar_id, start, end)
+            except Exception as err:  # noqa: BLE001 - propagate into UpdateFailed
+                raise UpdateFailed(f"Failed to read calendar {calendar_id}") from err
+
+            for event in events:
+                parent_key = self._make_parent_key(calendar_id, event)
+                observed_parents.add(parent_key)
+                updated = await self._manager.async_process_calendar_event(
+                    calendar_id=calendar_id,
+                    parent_key=parent_key,
+                    event=event,
+                )
+                if updated:
+                    _LOGGER.debug("Updated tasks for %s", parent_key)
+
+        removed = self._manager.remove_missing_calendar_events(observed_parents)
+        if removed:
+            _LOGGER.debug("Removed %s obsolete calendar derived tasks", removed)
+
+    def _make_parent_key(self, calendar_id: str, event: CalendarEvent) -> str:
+        """Generate a stable parent key for an event."""
+        uid = event.uid or f"{event.start}_{event.end}_{event.summary}"
+        return f"calendar:{calendar_id}:{uid}"

--- a/custom_components/mental_load_assistant/manifest.json
+++ b/custom_components/mental_load_assistant/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "mental_load_assistant",
+  "name": "Mental Load Assistant",
+  "codeowners": ["@openai"],
+  "config_flow": true,
+  "dependencies": ["calendar", "todo"],
+  "documentation": "https://github.com/openai/mental-load-list",
+  "iot_class": "cloud_polling",
+  "requirements": [],
+  "version": "0.1.0"
+}

--- a/custom_components/mental_load_assistant/services.yaml
+++ b/custom_components/mental_load_assistant/services.yaml
@@ -1,0 +1,33 @@
+add_manual_task:
+  name: Manuelle Aufgabe hinzufügen
+  description: Lässt die KI eine neue Aufgabe analysieren und als unterteilte To-dos eintragen.
+  fields:
+    summary:
+      description: Kurztitel der Aufgabe.
+      example: Solaranlage reparieren
+      required: true
+      selector:
+        text:
+    description:
+      description: Zusätzliche Details oder Kontext.
+      example: Wechselrichter zeigt Fehlercode an
+      required: false
+      selector:
+        text:
+          multiline: true
+    due:
+      description: Fälligkeitsdatum als ISO-8601-String.
+      example: "2024-07-01T18:00:00+02:00"
+      required: false
+      selector:
+        datetime:
+    household_context:
+      description: Zusätzliche Informationen zum Haushalt (z.B. Zuständigkeiten).
+      required: false
+      selector:
+        text:
+    entry_id:
+      description: Optionale Config-Entry-ID, falls mehrere Instanzen vorhanden sind.
+      required: false
+      selector:
+        text:

--- a/custom_components/mental_load_assistant/task_manager.py
+++ b/custom_components/mental_load_assistant/task_manager.py
@@ -1,0 +1,336 @@
+"""Task management for the Mental Load Assistant."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from typing import Callable, Iterable
+
+from homeassistant.components.calendar import CalendarEvent
+from homeassistant.components.todo import TodoItem, TodoItemStatus
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .ai_client import PlannedResponse
+from .const import (
+    ATTR_MENTAL_LOAD,
+    ATTR_PARENT_UID,
+    ATTR_SOURCE,
+    CALENDAR_SOURCE,
+    MANUAL_SOURCE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class StoredTask:
+    """Internal representation of a task."""
+
+    item: TodoItem
+    parent_key: str
+    is_parent: bool
+
+
+class MentalLoadTaskManager:
+    """Handle mental load tasks and synchronize them with Home Assistant."""
+
+    def __init__(
+        self,
+        *,
+        hass: HomeAssistant,
+        ai_client,
+        title: str,
+    ) -> None:
+        self._hass = hass
+        self._ai_client = ai_client
+        self._title = title
+        self._tasks: dict[str, StoredTask] = {}
+        self._parent_children: dict[str, set[str]] = defaultdict(set)
+        self._parent_meta: dict[str, dict[str, str | None]] = {}
+        self._event_signatures: dict[str, str] = {}
+        self._listeners: list[Callable[[], None]] = []
+
+    @property
+    def title(self) -> str:
+        """Return the configured title for the todo list."""
+
+        return self._title
+
+    def async_add_listener(self, listener: Callable[[], None]) -> None:
+        """Listen for updates."""
+
+        self._listeners.append(listener)
+
+    def _notify_listeners(self) -> None:
+        for listener in list(self._listeners):
+            listener()
+
+    def iter_items(self) -> list[TodoItem]:
+        """Return items sorted by due date then summary."""
+
+        items = [stored.item for stored in self._tasks.values()]
+        items.sort(key=_todo_sort_key)
+        return items
+
+    async def async_process_calendar_event(
+        self,
+        *,
+        calendar_id: str,
+        parent_key: str,
+        event: CalendarEvent,
+    ) -> bool:
+        """Process a calendar event and update tasks if necessary."""
+
+        signature = _event_signature(event)
+        if self._event_signatures.get(parent_key) == signature:
+            return False
+
+        plan = await self._ai_client.async_plan_for_calendar_event(
+            summary=event.summary,
+            description=event.description,
+            start=event.start,
+            end=event.end,
+        )
+
+        self._event_signatures[parent_key] = signature
+        self._parent_meta[parent_key] = {
+            ATTR_SOURCE: CALENDAR_SOURCE,
+            "summary": event.summary,
+            ATTR_MENTAL_LOAD: plan.mental_load,
+            "notes": plan.summary_notes,
+        }
+        due_dt = _parse_due(event.start) or _parse_due(event.end)
+        self._replace_parent_tasks(parent_key, plan, due_override=due_dt)
+        return True
+
+    async def async_create_manual_entry(
+        self,
+        *,
+        summary: str,
+        description: str | None,
+        due,
+        household_context: str | None = None,
+    ) -> str:
+        """Create a manual task request and return the parent uid."""
+
+        due_dt = _parse_due(due)
+        plan = await self._ai_client.async_plan_for_manual_request(
+            summary=summary,
+            description=description,
+            due=due_dt,
+            household_context=household_context,
+        )
+        parent_key = f"manual:{uuid.uuid4()}"
+        self._parent_meta[parent_key] = {
+            ATTR_SOURCE: MANUAL_SOURCE,
+            "summary": summary,
+            ATTR_MENTAL_LOAD: plan.mental_load,
+            "notes": plan.summary_notes,
+        }
+        self._replace_parent_tasks(parent_key, plan, due_override=due_dt)
+        parent_uid = self._parent_meta[parent_key]["parent_uid"]
+        return parent_uid
+
+    def remove_missing_calendar_events(self, valid_parent_keys: Iterable[str]) -> int:
+        """Remove tasks for calendar events that are no longer returned."""
+
+        valid = set(valid_parent_keys)
+        to_remove = [key for key in self._parent_meta if key.startswith("calendar:") and key not in valid]
+        for parent_key in to_remove:
+            self._remove_parent(parent_key)
+        if to_remove:
+            self._notify_listeners()
+        return len(to_remove)
+
+    def _replace_parent_tasks(
+        self,
+        parent_key: str,
+        plan: PlannedResponse,
+        *,
+        due_override: datetime | None = None,
+    ) -> None:
+        """Replace parent tasks with a new plan."""
+
+        existing = self._parent_children.pop(parent_key, set())
+        for uid in existing:
+            self._tasks.pop(uid, None)
+        parent_uid = str(uuid.uuid4())
+
+        meta = self._parent_meta.get(parent_key, {}).copy()
+        parent_summary = meta.get("summary") or "Mental Load Aufgabe"
+        notes = plan.summary_notes
+        if plan.mental_load:
+            notes = (notes or "") + f"\nMental Load Bewertung: {plan.mental_load}"
+
+        parent_item = TodoItem(
+            summary=parent_summary,
+            uid=parent_uid,
+            description=notes,
+            status=self._derive_parent_status(plan.tasks),
+            due=due_override,
+            extra={
+                ATTR_SOURCE: meta.get(ATTR_SOURCE),
+                ATTR_PARENT_UID: None,
+                ATTR_MENTAL_LOAD: plan.mental_load,
+            },
+        )
+
+        self._tasks[parent_uid] = StoredTask(parent_item, parent_key, True)
+        self._parent_children[parent_key] = set()
+        self._parent_meta[parent_key]["parent_uid"] = parent_uid
+
+        for planned in plan.tasks:
+            child_uid = str(uuid.uuid4())
+            child_item = TodoItem(
+                summary=f"{parent_summary}: {planned.title}",
+                uid=child_uid,
+                description=_child_description(planned),
+                status=TodoItemStatus.NEEDS_ACTION,
+                due=planned.due or due_override,
+                extra={
+                    ATTR_SOURCE: self._parent_meta[parent_key][ATTR_SOURCE],
+                    ATTR_PARENT_UID: parent_uid,
+                    ATTR_MENTAL_LOAD: planned.effort,
+                },
+            )
+            self._tasks[child_uid] = StoredTask(child_item, parent_key, False)
+            self._parent_children[parent_key].add(child_uid)
+
+        self._notify_listeners()
+
+    def _remove_parent(self, parent_key: str) -> None:
+        children = self._parent_children.pop(parent_key, set())
+        for uid in children:
+            self._tasks.pop(uid, None)
+        meta = self._parent_meta.pop(parent_key, None)
+        if meta and (parent_uid := meta.get("parent_uid")):
+            self._tasks.pop(parent_uid, None)
+
+    async def async_update_item(self, item: TodoItem) -> None:
+        """Handle item updates from Home Assistant."""
+
+        stored = self._tasks.get(item.uid)
+        if not stored:
+            _LOGGER.debug("Unknown task %s", item.uid)
+            return
+
+        new_status = item.status or TodoItemStatus.NEEDS_ACTION
+        stored.item = replace(stored.item, status=new_status)
+
+        if stored.is_parent:
+            # Propagate to children if user marks parent completed
+            if new_status == TodoItemStatus.COMPLETED:
+                for child_uid in self._parent_children.get(stored.parent_key, set()):
+                    child = self._tasks[child_uid]
+                    child.item = replace(child.item, status=TodoItemStatus.COMPLETED)
+            elif new_status == TodoItemStatus.NEEDS_ACTION:
+                for child_uid in self._parent_children.get(stored.parent_key, set()):
+                    child = self._tasks[child_uid]
+                    if child.item.status == TodoItemStatus.COMPLETED:
+                        child.item = replace(child.item, status=TodoItemStatus.NEEDS_ACTION)
+        else:
+            parent_uid = (stored.item.extra or {}).get(ATTR_PARENT_UID)
+            if parent_uid and (parent := self._tasks.get(parent_uid)):
+                parent.item = replace(
+                    parent.item,
+                    status=self._derive_parent_status_from_children(parent_uid),
+                )
+
+        self._notify_listeners()
+
+    async def async_delete_item(self, uid: str) -> None:
+        """Remove an item from the list."""
+
+        stored = self._tasks.get(uid)
+        if not stored:
+            return
+        if stored.is_parent:
+            self._remove_parent(stored.parent_key)
+        else:
+            self._tasks.pop(uid, None)
+            children = self._parent_children.get(stored.parent_key)
+            if children and uid in children:
+                children.remove(uid)
+            parent_uid = (stored.item.extra or {}).get(ATTR_PARENT_UID)
+            if parent_uid and (parent := self._tasks.get(parent_uid)):
+                parent.item = replace(
+                    parent.item,
+                    status=self._derive_parent_status_from_children(parent_uid),
+                )
+        self._notify_listeners()
+
+    def _derive_parent_status(self, tasks) -> TodoItemStatus:
+        if not tasks:
+            return TodoItemStatus.NEEDS_ACTION
+        return TodoItemStatus.IN_PROGRESS
+
+    def _derive_parent_status_from_children(self, parent_uid: str) -> TodoItemStatus:
+        parent_task = self._tasks.get(parent_uid)
+        if not parent_task:
+            return TodoItemStatus.NEEDS_ACTION
+        children = [
+            self._tasks[uid].item
+            for uid in self._parent_children.get(parent_task.parent_key, set())
+            if uid in self._tasks
+        ]
+        if not children:
+            return TodoItemStatus.NEEDS_ACTION
+        if all(child.status == TodoItemStatus.COMPLETED for child in children):
+            return TodoItemStatus.COMPLETED
+        if any(child.status == TodoItemStatus.IN_PROGRESS for child in children):
+            return TodoItemStatus.IN_PROGRESS
+        if any(child.status == TodoItemStatus.COMPLETED for child in children):
+            return TodoItemStatus.IN_PROGRESS
+        return TodoItemStatus.NEEDS_ACTION
+
+
+def _child_description(planned) -> str | None:
+    parts = []
+    if planned.description:
+        parts.append(planned.description)
+    if planned.effort:
+        parts.append(f"Mental Load: {planned.effort}")
+    if planned.notes:
+        parts.append(planned.notes)
+    return "\n".join(parts) if parts else None
+
+
+def _event_signature(event: CalendarEvent) -> str:
+    return "|".join(
+        (
+            event.summary or "",
+            event.description or "",
+            _iso_or_empty(event.start),
+            _iso_or_empty(event.end),
+        )
+    )
+
+
+def _iso_or_empty(value) -> str:
+    if isinstance(value, datetime):
+        return dt_util.as_utc(value).isoformat()
+    return ""
+
+
+def _parse_due(value) -> datetime | None:
+    if isinstance(value, datetime):
+        return dt_util.as_utc(value)
+    if isinstance(value, date):
+        return dt_util.as_utc(dt_util.start_of_local_day(value))
+    if isinstance(value, str):
+        try:
+            return dt_util.as_utc(dt_util.parse_datetime(value))
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def _todo_sort_key(item: TodoItem):
+    return (
+        item.due or datetime.max.replace(tzinfo=dt_util.UTC),
+        item.summary.lower(),
+    )

--- a/custom_components/mental_load_assistant/todo.py
+++ b/custom_components/mental_load_assistant/todo.py
@@ -1,0 +1,67 @@
+"""Todo platform for the Mental Load Assistant."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.todo import TodoItem, TodoListEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DATA_MANAGER, DOMAIN
+from .task_manager import MentalLoadTaskManager
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the todo entity."""
+
+    data = hass.data[DOMAIN][entry.entry_id]
+    manager: MentalLoadTaskManager = data[DATA_MANAGER]
+
+    async_add_entities([MentalLoadTodoList(manager, entry)])
+
+
+class MentalLoadTodoList(TodoListEntity):
+    """Representation of the mental load todo list."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, manager: MentalLoadTaskManager, entry: ConfigEntry) -> None:
+        self._manager = manager
+        self._attr_unique_id = entry.entry_id
+        self._attr_name = f"{manager.title} Aufgaben"
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._manager.async_add_listener(self.async_write_ha_state)
+
+    async def async_get_items(self) -> list[TodoItem]:
+        return self._manager.iter_items()
+
+    async def async_create_item(self, item: TodoItem) -> str:
+        parent_uid = await self._manager.async_create_manual_entry(
+            summary=item.summary,
+            description=item.description,
+            due=item.due,
+            household_context=None,
+        )
+        return parent_uid
+
+    async def async_update_item(self, item: TodoItem) -> None:
+        await self._manager.async_update_item(item)
+
+    async def async_delete_item(self, uid: str) -> None:
+        await self._manager.async_delete_item(uid)
+
+    @property
+    def icon(self) -> str | None:
+        return "mdi:clipboard-text-multiple"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {}


### PR DESCRIPTION
## Summary
- add a custom Mental Load Assistant integration that analyses calendar events with an AI (with heuristic fallback) and manages generated tasks
- expose a todo entity plus service support for manual task submissions with mental-load breakdown metadata
- provide configuration and options flows along with documentation and service descriptions

## Testing
- python -m compileall custom_components

------
https://chatgpt.com/codex/tasks/task_e_68dd18cac96c83218a7a0a45c66a023f